### PR TITLE
Greater walking speed variance

### DIFF
--- a/PoGo.NecroBot.Logic/Navigation.cs
+++ b/PoGo.NecroBot.Logic/Navigation.cs
@@ -228,8 +228,8 @@ namespace PoGo.NecroBot.Logic
                 {
                     if (millisecondsUntilVariant >= SpeedVariantSec)
                     {
-                        var randomMin = session.LogicSettings.WalkingSpeedInKilometerPerHour - 1.2;
-                        var randomMax = session.LogicSettings.WalkingSpeedInKilometerPerHour + 1.2;
+                        var randomMin = session.LogicSettings.WalkingSpeedInKilometerPerHour - 3.2;
+                        var randomMax = session.LogicSettings.WalkingSpeedInKilometerPerHour + 3.2;
                         var RandomWalkSpeed = rw.NextDouble() * (randomMax - randomMin) + randomMin;
 
                         session.EventDispatcher.Send(new HumanWalkingEvent


### PR DESCRIPTION

## Short Description:

Greater walking speed variance.

## Fixes (provide links to github issues if you can):

I think 1.2 on either side (2.4 total) is too little variation to simulate humanlike conditions. Increased that range by 2 on either side.

Will work on implementing those values to the config.json