### PR TITLE
Improving use of incubators

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
 using POGOProtos.Inventory.Item;
@@ -66,7 +67,12 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             var newRememberedIncubators = new List<IncubatorUsage>();
 
-            foreach (var incubator in incubators)
+            // Find out if there are only 10km-eggs (special case)
+            var only10kmEggs = false;
+            var testIfOnly10kmEggs = unusedEggs.FirstOrDefault(x => x.EggKmWalkedTarget < 10);
+            if (testIfOnly10kmEggs == null) only10kmEggs = true;
+
+                foreach (var incubator in incubators)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -81,8 +87,17 @@ namespace PoGo.NecroBot.Logic.Tasks
                     if (egg == null)
                         continue;
 
-                    //avoid using 2/5 km eggs with limited incubator
-                    if (egg.EggKmWalkedTarget < session.LogicSettings.UseEggIncubatorMinKm && incubator.ItemId != ItemId.ItemIncubatorBasicUnlimited)
+                    // Avoid using 10 km egg until you are level 20 in order to get higher 
+                    // initial CP on the high IV 10 km Pokémons (unless you ONLY have 10km-eggs)
+                    if (egg.EggKmWalkedTarget == 10 && playerStats.Level < 20 && !only10kmEggs)
+                    {
+                        Logger.Write("Player below level 20, saving this 10 km Egg for later.", LogLevel.Egg);
+                        continue;
+                    }
+
+                    // Avoid using 2/5 km eggs with limited incubator - IF setting is 10!
+                    if (egg.EggKmWalkedTarget < session.LogicSettings.UseEggIncubatorMinKm 
+                        && incubator.ItemId != ItemId.ItemIncubatorBasicUnlimited)
                         continue;
 
                     var response = await session.Client.Inventory.UseItemEggIncubator(incubator.Id, egg.Id);


### PR DESCRIPTION
## Improved use of incubators

## Fixes

Adds logic to avoid using 10 km eggs until you are level 20 in order to get
higher initial CP on the high IV 10 km Pokémons. That is unless you ONLY have
10km-eggs - then it will proceed as before.

A suggestion is to also change the default setting for UseItemEggIncubator from 2 to 10. That means we
will avoid using limited incubators on lesser eggs than 10. Which is the original intention of the code as I can see telling from the comments. I haven't included that in this commit though.