### PR TITLE
Added pokemon catch count, pokestop visit count and sniper snipe coun…

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -13,6 +13,12 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
     {
         bool UseWebsocket { get; }
         bool CatchPokemon { get; }
+        int CatchPokemonLimit { get; }
+        int CatchPokemonLimitMinutes { get; }
+        int PokeStopLimit { get; }
+        int PokeStopLimitMinutes { get; }
+        int SnipeCountLimit { get; }
+        int SnipeRestSeconds { get; }
         bool TransferWeakPokemon { get; }
         bool DisableHumanWalking { get; }
         bool CheckForUpdates { get; }

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -28,6 +28,12 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool TransferConfigAndAuthOnUpdate => _settings.UpdateSettings.TransferConfigAndAuthOnUpdate;
         public bool UseWebsocket => _settings.WebsocketsSettings.UseWebsocket;
         public bool CatchPokemon => _settings.PokemonSettings.CatchPokemon;
+        public int CatchPokemonLimit => _settings.PokemonSettings.CatchPokemonLimit;
+        public int CatchPokemonLimitMinutes => _settings.PokemonSettings.CatchPokemonLimitMinutes;
+        public int PokeStopLimit => _settings.PokemonSettings.PokeStopLimit;
+        public int PokeStopLimitMinutes => _settings.PokemonSettings.PokeStopLimitMinutes;
+        public int SnipeCountLimit => _settings.PokemonSettings.SnipeCountLimit;
+        public int SnipeRestSeconds => _settings.PokemonSettings.SnipeRestSeconds;
         public bool TransferWeakPokemon => _settings.PokemonSettings.TransferWeakPokemon;
         public bool DisableHumanWalking => _settings.LocationSettings.DisableHumanWalking;
         public int MaxBerriesToUsePerPokemon => _settings.PokemonSettings.MaxBerriesToUsePerPokemon;

--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -4,6 +4,12 @@ namespace PoGo.NecroBot.Logic.Model.Settings
     {
         /*Catch*/
         public bool CatchPokemon = true;
+        public int SnipeRestSeconds = 10 * 60;
+        public int SnipeCountLimit = 39;
+        public int CatchPokemonLimit = 998;
+        public int CatchPokemonLimitMinutes = 60 * 24 + 30;
+        public int PokeStopLimit = 1998;
+        public int PokeStopLimitMinutes = 60 * 24 + 30;
         public int DelayBetweenPokemonCatch = 2000;
         /*Incense*/
         public bool UseIncenseConstantly;

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Service\DirectionsService.cs" />
     <Compile Include="Service\TelegramService.cs" />
     <Compile Include="Model\Settings\LogicSettings.cs" />
+    <Compile Include="State\SessionStats.cs" />
     <Compile Include="Strategies\Walk\FlyStrategy.cs" />
     <Compile Include="Strategies\Walk\GoogleStrategy.cs" />
     <Compile Include="Strategies\Walk\HumanPathWalkingStrategy.cs" />
@@ -246,7 +247,7 @@
     <Compile Include="State\LoginState.cs" />
     <Compile Include="Event\NoticeEvent.cs" />
     <Compile Include="Event\PokemonEvolveEvent.cs" />
-    <Compile Include="State\PositionCheckState.cs" />
+    <Compile Include="State\LoadSaveState.cs" />
     <Compile Include="State\StateMachine.cs" />
     <Compile Include="Tasks\FarmPokestopsGPXTask.cs" />
     <Compile Include="Tasks\FarmPokestopsTask.cs" />

--- a/PoGo.NecroBot.Logic/State/LoadSaveState.cs
+++ b/PoGo.NecroBot.Logic/State/LoadSaveState.cs
@@ -7,12 +7,13 @@ using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Common;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.Utils;
+using System.Collections.Generic;
 
 #endregion
 
 namespace PoGo.NecroBot.Logic.State
 {
-    public class PositionCheckState : IState
+    public class LoadSaveState : IState
     {
         public async Task<IState> Execute(ISession session, CancellationToken cancellationToken)
         {
@@ -26,15 +27,15 @@ namespace PoGo.NecroBot.Logic.State
                 {
                     var distance = LocationUtils.CalculateDistanceInMeters(latLngFromFile.Item1, latLngFromFile.Item2,
                         session.Settings.DefaultLatitude, session.Settings.DefaultLongitude);
-                    var lastModified = File.Exists(coordsPath) ? (DateTime?) File.GetLastWriteTime(coordsPath) : null;
+                    var lastModified = File.Exists(coordsPath) ? (DateTime?)File.GetLastWriteTime(coordsPath) : null;
                     if (lastModified != null)
                     {
                         var hoursSinceModified = (DateTime.Now - lastModified).HasValue
-                            ? (double?) ((DateTime.Now - lastModified).Value.Minutes/60.0)
+                            ? (double?)((DateTime.Now - lastModified).Value.Minutes / 60.0)
                             : null;
                         if (hoursSinceModified != null && hoursSinceModified != 0)
                         {
-                            var kmph = distance/1000/(double) hoursSinceModified;
+                            var kmph = distance / 1000 / (double)hoursSinceModified;
                             if (kmph < 80) // If speed required to get to the default location is < 80km/hr
                             {
                                 File.Delete(coordsPath);
@@ -83,6 +84,64 @@ namespace PoGo.NecroBot.Logic.State
                         Message = session.Translation.GetTranslation(TranslationString.GoogleAPIWarning)
                     });
                 }
+            }
+
+            List<Int64> list = new List<Int64>();
+            // for pokestops
+            try
+            {
+                var path = Path.Combine(session.LogicSettings.ProfileConfigPath, "PokestopTS.txt");
+                if (File.Exists(path))
+                {
+                    var content = File.ReadLines(path);
+                    foreach (var c in content)
+                    {
+                        if (c.Length > 0)
+                        {
+                            list.Add(Convert.ToInt64(c));
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                session.EventDispatcher.Send(new ErrorEvent
+                {
+                    Message = "Garbage information in PokestopTS.txt"
+                });
+            }
+            foreach (var l in list)
+            {
+                session.Stats.PokeStopTimestamps.Add(l);
+            }
+
+            // for pokemons
+            list = new List<Int64>();
+            try
+            {
+                var path = Path.Combine(session.LogicSettings.ProfileConfigPath, "PokemonTS.txt");
+                if (File.Exists(path))
+                {
+                    var content = File.ReadLines(path);
+                    foreach (var c in content)
+                    {
+                        if (c.Length > 0)
+                        {
+                            list.Add(Convert.ToInt64(c));
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                session.EventDispatcher.Send(new ErrorEvent
+                {
+                    Message = "Garbage information in PokemonTS.txt"
+                });
+            }
+            foreach (var l in list)
+            {
+                session.Stats.PokemonTimestamps.Add(l);
             }
 
             await Task.Delay(100, cancellationToken);

--- a/PoGo.NecroBot.Logic/State/LoginState.cs
+++ b/PoGo.NecroBot.Logic/State/LoginState.cs
@@ -145,7 +145,7 @@ namespace PoGo.NecroBot.Logic.State
                 System.Environment.Exit(1);
             }
             
-            return new PositionCheckState();
+            return new LoadSaveState();
         }
 
         private static async Task CheckLogin(ISession session, CancellationToken cancellationToken)

--- a/PoGo.NecroBot.Logic/State/Session.cs
+++ b/PoGo.NecroBot.Logic/State/Session.cs
@@ -23,6 +23,7 @@ namespace PoGo.NecroBot.Logic.State
         IEventDispatcher EventDispatcher { get; }
         TelegramService Telegram { get; set; }
         KillSwitch KillSwitch { get; }
+        SessionStats Stats { get; }
     }
 
 
@@ -35,6 +36,7 @@ namespace PoGo.NecroBot.Logic.State
             EventDispatcher = new EventDispatcher();
             Translation = Common.Translation.Load(logicSettings);
             Reset(settings, LogicSettings);
+            Stats = new SessionStats();
         }
 
         public ISettings Settings { get; set; }
@@ -55,6 +57,8 @@ namespace PoGo.NecroBot.Logic.State
         public TelegramService Telegram { get; set; }
 
         public KillSwitch KillSwitch { get; private set; }
+
+        public SessionStats Stats { get; set; }
 
         public void Reset(ISettings settings, ILogicSettings logicSettings)
         {

--- a/PoGo.NecroBot.Logic/State/SessionStats.cs
+++ b/PoGo.NecroBot.Logic/State/SessionStats.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PoGo.NecroBot.Logic.State
+{
+    public class SessionStats
+    {
+        public int SnipeCount { get; set; }
+        public DateTime LastSnipeTime { get; set; }
+        public List<Int64> PokeStopTimestamps { get; private set; }
+        public List<Int64> PokemonTimestamps { get; private set; }
+
+        public SessionStats()
+        {
+            PokemonTimestamps = new List<Int64>();
+            PokeStopTimestamps = new List<Int64>();
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/Tasks/FavoritePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FavoritePokemonTask.cs
@@ -29,7 +29,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 if (session.LogicSettings.AutoFavoritePokemon && perfection >= session.LogicSettings.FavoriteMinIvPercentage && pokemon.Favorite!=1)
                 {
-                    await session.Client.Inventory.SetFavoritePokemon(pokemon.Id, true);
+                    await session.Client.Inventory.SetFavoritePokemon((long)pokemon.Id, true);
 
                     session.EventDispatcher.Send(new NoticeEvent
                     {

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -188,6 +188,24 @@ namespace PoGo.NecroBot.Logic.Tasks
             return true;
         }
 
+        private static bool CheckSnipeConditions(ISession session)
+        {
+            session.EventDispatcher.Send(new SnipeEvent { Message = "Sniper count " + session.Stats.SnipeCount });
+            if (session.Stats.SnipeCount >= session.LogicSettings.SnipeCountLimit)
+            {
+                if ((DateTime.Now - session.Stats.LastSnipeTime).TotalSeconds > session.LogicSettings.SnipeRestSeconds)
+                {
+                    session.Stats.SnipeCount = 0;
+                }
+                else
+                {
+                    session.EventDispatcher.Send(new SnipeEvent { Message = "Sniper need to take a rest before your account is rekt." });
+                    return false;
+                }
+            }
+            return true;
+        }
+
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
             if (_lastSnipe.AddMilliseconds(session.LogicSettings.MinDelayBetweenSnipes) > DateTime.Now)
@@ -245,7 +263,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                                     if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                         return;
-
+                                    if (!CheckSnipeConditions(session)) return;
                                     await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
                                 }
                             }
@@ -271,6 +289,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                                     if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                         return;
+                                    if (!CheckSnipeConditions(session)) return;
 
                                     await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
                                 }
@@ -297,6 +316,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                                     if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                         return;
+                                    if (!CheckSnipeConditions(session)) return;
 
                                     await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
                                 }
@@ -323,6 +343,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                                     if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                         return;
+                                    if (!CheckSnipeConditions(session)) return;
 
                                     await Snipe(session, pokemonIds, location.Latitude, location.Longitude, cancellationToken);
                                 }
@@ -363,6 +384,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                                     {
                                         if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                             return;
+                                        if (!CheckSnipeConditions(session)) return;
 
                                         await Snipe(session, pokemonIds, pokemonLocation.latitude, pokemonLocation.longitude, cancellationToken);
                                     }
@@ -500,6 +522,11 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             _lastSnipe = DateTime.Now;
 
+            if (catchedPokemon)
+            {
+                session.Stats.SnipeCount++;
+                session.Stats.LastSnipeTime = _lastSnipe;
+            }
             session.EventDispatcher.Send(new SnipeModeEvent { Active = false });
             await Task.Delay(session.LogicSettings.DelayBetweenPlayerActions, cancellationToken);
 


### PR DESCRIPTION
Added pokemon catch count, pokestop visit count and sniper snipe count to prevent being softbanned.

Options added:
Under "PokemonSettings": 
"SnipeRestSeconds": 660, (Will stop sniping for this amount of seconds once SnipeCountLimit is reached)
"SnipeCountLimit": 39, (Rest after sniping this amount of pokemons)
"CatchPokemonLimit": 999, (Will not catch more than this amount of pokemons for the duration of CatchPokemonLimitMinutes)
"CatchPokemonLimitMinutes": 1470,
"PokeStopLimit": 1998, (Will not visit more than this amount of pokestops for the duration of PokeStopLimitMinutes)
"PokeStopLimitMinutes": 1470,

Fixes:

No longer thrash SSDs. Will only save location upon exit instead of doing so every time player moves.