### PR TITLE
Add more properties to PokemonCaptureEvent

### DIFF
--- a/PoGo.NecroBot.Logic/Event/PokemonCaptureEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/PokemonCaptureEvent.cs
@@ -28,5 +28,11 @@ namespace PoGo.NecroBot.Logic.Event
         public CatchPokemonResponse.Types.CatchStatus Status;
         public double Latitude;
         public double Longitude;
+        public string SpawnPointId;
+        public ulong EncounterId;
+        public PokemonMove Move1;
+        public PokemonMove Move2;
+        public long Expires;
+        public string CatchTypeText;
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -228,6 +228,23 @@ namespace PoGo.NecroBot.Logic.Tasks
                     : encounter is DiskEncounterResponse
                         ? session.Translation.GetTranslation(TranslationString.CatchTypeLure)
                         : session.Translation.GetTranslation(TranslationString.CatchTypeIncense);
+                evt.CatchTypeText = encounter is EncounterResponse
+                    ? "normal"
+                    : encounter is DiskEncounterResponse
+                        ? "lure"
+                        : "incense";
+                evt.Id = encounter is EncounterResponse ? pokemon.PokemonId : encounter?.PokemonData.PokemonId;
+                evt.EncounterId = encounter is EncounterResponse || encounter is IncenseEncounterResponse
+                    ? pokemon.EncounterId
+                    : encounterId;
+                evt.Move1 = PokemonInfo.GetPokemonMove1(encounter is EncounterResponse
+                    ? encounter.WildPokemon?.PokemonData
+                    : encounter?.PokemonData);
+                evt.Move2 = PokemonInfo.GetPokemonMove2(encounter is EncounterResponse
+                    ? encounter.WildPokemon?.PokemonData
+                    : encounter?.PokemonData);
+                evt.Expires = pokemon.ExpirationTimestampMs;
+                evt.SpawnPointId = pokemon.SpawnPointId;
                 evt.Id = encounter is EncounterResponse ? pokemon.PokemonId : encounter?.PokemonData.PokemonId;
                 evt.Level =
                     PokemonInfo.GetLevel(encounter is EncounterResponse


### PR DESCRIPTION
Better integration with PogoLocationFeeder (https://github.com/5andr0/PogoLocationFeeder).
By adding some more properties to the PokemonCaptureEvent, we can retrieve more information about captured pokémon and share them with the rest of the pogolocationfeeder userbase.

public string SpawnPointId;
public ulong EncounterId;
public PokemonMove Move1;
public PokemonMove Move2;
public long Expires;
public string CatchTypeText;

Note: CatchTypeText is almost the same as CatchType, but not translated.
I doubt the current one needs to be translated anyway, but didn't wanna break backwards compatibility with other parties.