### PR TITLE
Fix #383 Necro crashing when a lured pokemon is encountered.

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -243,9 +243,10 @@ namespace PoGo.NecroBot.Logic.Tasks
                 evt.Move2 = PokemonInfo.GetPokemonMove2(encounter is EncounterResponse
                     ? encounter.WildPokemon?.PokemonData
                     : encounter?.PokemonData);
-                evt.Expires = pokemon.ExpirationTimestampMs;
-                evt.SpawnPointId = pokemon.SpawnPointId;
-                evt.Id = encounter is EncounterResponse ? pokemon.PokemonId : encounter?.PokemonData.PokemonId;
+                evt.Expires = pokemon?.ExpirationTimestampMs ?? 0;
+                evt.SpawnPointId = encounter is EncounterResponse || encounter is IncenseEncounterResponse
+                    ? pokemon.SpawnPointId
+                    : currentFortData?.Id;
                 evt.Level =
                     PokemonInfo.GetLevel(encounter is EncounterResponse
                         ? encounter.WildPokemon?.PokemonData

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -233,7 +233,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     : encounter is DiskEncounterResponse
                         ? "lure"
                         : "incense";
-                evt.Id = encounter is EncounterResponse || encounter is IncenseEncounterResponse 
+                evt.Id = encounter is EncounterResponse 
                     ? pokemon.PokemonId : encounter?.PokemonData.PokemonId;
                 evt.EncounterId = encounter is EncounterResponse || encounter is IncenseEncounterResponse
                     ? pokemon.EncounterId

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -233,7 +233,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     : encounter is DiskEncounterResponse
                         ? "lure"
                         : "incense";
-                evt.Id = encounter is EncounterResponse ? pokemon.PokemonId : encounter?.PokemonData.PokemonId;
+                evt.Id = encounter is EncounterResponse || encounter is IncenseEncounterResponse 
+                    ? pokemon.PokemonId : encounter?.PokemonData.PokemonId;
                 evt.EncounterId = encounter is EncounterResponse || encounter is IncenseEncounterResponse
                     ? pokemon.EncounterId
                     : encounterId;


### PR DESCRIPTION
Fix #383,  #364, #367 Necro crashing when a lured pokemon is encountered.

My previous PR didn't handle the case Lure pokemon properly for the SpawnPointId & Expires properties.
My apologies.