### PR TITLE
Fix StartupWelcomeDelay not working (issue #365)

### DIFF
--- a/PoGo.NecroBot.Logic/State/PositionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/PositionCheckState.cs
@@ -70,6 +70,9 @@ namespace PoGo.NecroBot.Logic.State
                         session.Client.CurrentLongitude),
                 RequireInput = session.LogicSettings.StartupWelcomeDelay
             });
+            // Bugfix: Make sure to wait for keypress
+            if (session.LogicSettings.StartupWelcomeDelay) Console.ReadKey();
+
 
             if (session.LogicSettings.UseGoogleWalk && !session.LogicSettings.UseGpxPathing)
             {


### PR DESCRIPTION
## Fix StartupWelcomeDelay not working (issue #365)

Simple fix. The eventhandler to show the console message doesn't include code for actually waiting. This is handled in the proposed manner other places in the code (Program.cs, APIFailureStrategy.cs), so applying that logic here as well.