### PR TITLE
ResumeTrack/Seg/Pt initialization for GPX and "API throttling", to prevent long jumps when pathing, and refactoring of code to ensure PokeStopListEvent always sends the full list of nearby stops when using GPX

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -153,5 +153,8 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         bool UseGoogleWalkCache { get; }
         string GoogleApiKey { get; }
         string GoogleHeuristic { get; }
+        int ResumeTrack { get; }
+        int ResumeTrackSeg { get; }
+        int ResumeTrackPt { get; }
     }
 }

--- a/PoGo.NecroBot.Logic/Model/Settings/LocationConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LocationConfig.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace PoGo.NecroBot.Logic.Model.Settings
 {
     public class LocationConfig
@@ -13,5 +15,11 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool RandomlyPauseAtStops = true;
         public int MaxSpawnLocationOffset = 10;
         public int MaxTravelDistanceInMeters = 1000;
+        [JsonIgnore]
+        public int ResumeTrack = 0;
+        [JsonIgnore]
+        public int ResumeTrackSeg = 0;
+        [JsonIgnore]
+        public int ResumeTrackPt = 0;
     }
 }

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -158,5 +158,8 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseSnipeLimit => _settings.SnipeConfig.UseSnipeLimit;
         public bool UsePokeStopLimit => _settings.PokeStopConfig.UsePokeStopLimit;
         public bool UseCatchLimit => _settings.PokemonConfig.UseCatchLimit;
+        public int ResumeTrack => _settings.LocationConfig.ResumeTrack;
+        public int ResumeTrackSeg => _settings.LocationConfig.ResumeTrackSeg;
+        public int ResumeTrackPt => _settings.LocationConfig.ResumeTrackPt;
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -21,32 +21,41 @@ namespace PoGo.NecroBot.Logic.Tasks
 {
     public static class FarmPokestopsGpxTask
     {
-        private static int curTrkSeg;
-        private static int curTrkPt;
         private static DateTime _lastTasksCall = DateTime.Now;
+        private static int _resumeTrack = 0;
+        private static int _resumeTrackSeg = 0;
+        private static int _resumeTrackPt = 0;
 
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
             var tracks = GetGpxTracks(session);
             var eggWalker = new EggWalker(1000, session);
 
-            for (var curTrk = 0; curTrk < tracks.Count; curTrk++)
+            if (_resumeTrack + _resumeTrackSeg + _resumeTrackPt == 0)
             {
+                _resumeTrack = session.LogicSettings.ResumeTrack;
+                _resumeTrackSeg = session.LogicSettings.ResumeTrackSeg;
+                _resumeTrackPt = session.LogicSettings.ResumeTrackPt;
+            }
+
+            for (var curTrk = _resumeTrack; curTrk < tracks.Count; curTrk++)
+            {
+                _resumeTrack = curTrk;
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var track = tracks.ElementAt(curTrk);
                 var trackSegments = track.Segments;
 
-                if (curTrkSeg >= trackSegments.Count) curTrkSeg = 0;
-                for (; curTrkSeg < trackSegments.Count; curTrkSeg++)
+                for (var curTrkSeg = _resumeTrackSeg; curTrkSeg < trackSegments.Count; curTrkSeg++)
                 {
+                    _resumeTrackSeg = curTrkSeg;
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var trackPoints = track.Segments.ElementAt(curTrkSeg).TrackPoints;
+                    var trackPoints = trackSegments.ElementAt(curTrkSeg).TrackPoints;
 
-                    if (curTrkPt >= trackPoints.Count) curTrkPt = 0;
-                    for (; curTrkPt < trackPoints.Count; curTrkPt++)
+                    for (var curTrkPt = _resumeTrackPt; curTrkPt < trackPoints.Count; curTrkPt++)
                     {
+                        _resumeTrackPt = curTrkPt;
                         cancellationToken.ThrowIfCancellationRequested();
 
                         var nextPoint = trackPoints.ElementAt(curTrkPt);
@@ -65,56 +74,6 @@ namespace PoGo.NecroBot.Logic.Tasks
                                         session.Client.CurrentLongitude)
                             });
                             break;
-                        }
-
-                        var pokestopList = await GetPokeStops(session);
-                        
-                        while (pokestopList.Any())
-                        // warning: this is never entered due to ps cooldowns from UseNearbyPokestopsTask 
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-
-                            pokestopList =
-                                pokestopList.OrderBy(
-                                    i =>
-                                        LocationUtils.CalculateDistanceInMeters(session.Client.CurrentLatitude,
-                                            session.Client.CurrentLongitude, i.Latitude, i.Longitude)).ToList();
-                            var pokeStop = pokestopList[0];
-                            pokestopList.RemoveAt(0);
-
-                            var fortInfo =
-                                await session.Client.Fort.GetFort(pokeStop.Id, pokeStop.Latitude, pokeStop.Longitude);
-
-                            if (pokeStop.LureInfo != null)
-                            {
-                                await CatchLurePokemonsTask.Execute(session, pokeStop, cancellationToken);
-                            }
-
-                            var fortSearch =
-                                await session.Client.Fort.SearchFort(pokeStop.Id, pokeStop.Latitude, pokeStop.Longitude);
-
-                            if (fortSearch.ExperienceAwarded > 0)
-                            {
-                                session.EventDispatcher.Send(new FortUsedEvent
-                                {
-                                    Id = pokeStop.Id,
-                                    Name = fortInfo.Name,
-                                    Exp = fortSearch.ExperienceAwarded,
-                                    Gems = fortSearch.GemsAwarded,
-                                    Items = StringUtils.GetSummedFriendlyNameOfItemAwardList(fortSearch.ItemsAwarded),
-                                    Latitude = pokeStop.Latitude,
-                                    Longitude = pokeStop.Longitude
-                                });
-                            }
-                            else
-                            {
-                                await RecycleItemsTask.Execute(session, cancellationToken);
-                            }
-
-                            if (fortSearch.ItemsAwarded.Count > 0)
-                            {
-                                await session.Inventory.RefreshCachedInventory();
-                            }
                         }
 
                         if (DateTime.Now > _lastTasksCall)
@@ -187,8 +146,11 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                         await eggWalker.ApplyDistance(distance, cancellationToken);
                     } //end trkpts
+                    _resumeTrackPt = 0;
                 } //end trksegs
+                _resumeTrackSeg = 0;
             } //end tracks
+            _resumeTrack = 0;
         }
 
         private static List<GpxReader.Trk> GetGpxTracks(ISession session)
@@ -196,49 +158,6 @@ namespace PoGo.NecroBot.Logic.Tasks
             var xmlString = File.ReadAllText(session.LogicSettings.GpxFile);
             var readgpx = new GpxReader(xmlString, session);
             return readgpx.Tracks;
-        }
-
-        //Please do not change GetPokeStops() in this file, it's specifically set
-        //to only find stops within 40 meters
-        //this is for gpx pathing, we are not going to the pokestops,
-        //so do not make it more than 40 because it will never get close to those stops.
-        private static async Task<List<FortData>> GetPokeStops(ISession session)
-        {
-            List<FortData> pokeStops = await UpdateFortsData(session);
-            session.EventDispatcher.Send(new PokeStopListEvent { Forts = pokeStops });
-
-            // Wasn't sure how to make this pretty. Edit as needed.
-            pokeStops = pokeStops.Where(
-                    i =>
-                        i.Type == FortType.Checkpoint &&
-                        i.CooldownCompleteTimestampMs < DateTime.UtcNow.ToUnixTime() &&
-                        ( // Make sure PokeStop is within 40 meters or else it is pointless to hit it
-                            LocationUtils.CalculateDistanceInMeters(
-                                session.Client.CurrentLatitude, session.Client.CurrentLongitude,
-                                i.Latitude, i.Longitude) < 40) ||
-                        session.LogicSettings.MaxTravelDistanceInMeters == 0
-                ).ToList();
-
-            return pokeStops.ToList();
-        }
-
-        private static async Task<List<FortData>> UpdateFortsData(ISession session)
-        {
-            var mapObjects = await session.Client.Map.GetMapObjects();
-            
-            var pokeStops = mapObjects.Item1.MapCells.SelectMany(i => i.Forts)
-                .Where(
-                    i =>
-                        i.Type == FortType.Checkpoint &&
-                        i.CooldownCompleteTimestampMs < DateTime.UtcNow.ToUnixTime() &&
-                        (
-                            LocationUtils.CalculateDistanceInMeters(
-                                session.Client.CurrentLatitude, session.Client.CurrentLongitude,
-                                i.Latitude, i.Longitude) < session.LogicSettings.MaxTravelDistanceInMeters) ||
-                        session.LogicSettings.MaxTravelDistanceInMeters == 0
-                );
-
-            return pokeStops.ToList();
         }
     }
 }


### PR DESCRIPTION
Although I have added three new values to LocationConfig, they are not stored in the configuration thanks to JsonIgnore (they are calculated on-the-fly and not needed there), so they don't need to be documented. 

I have made two changes in this pull request as FarmPokestopsGPXTask is affected in both, the primary one is the ResumeTrack/Seg/Pt fixes. However, using PokeEase with GPX generates lots of errors without the PokeStopListEvent fix, so I included that also as it is becoming ever more popular as a GUI for NecroBot.
