### PR TITLE
Manual Snipe while NecroBot is working

### DIFF
--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Tasks\Login.cs" />
     <Compile Include="Tasks\RecycleItemsTask.cs" />
     <Compile Include="Tasks\RenamePokemonTask.cs" />
+    <Compile Include="Tasks\SnipeMSniperTask.cs" />
     <Compile Include="Tasks\SnipePokemonTask.cs" />
     <Compile Include="Tasks\TransferDuplicatePokemonTask.cs" />
     <Compile Include="Event\UseLuckyEggEvent.cs" />

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -98,7 +98,10 @@ namespace PoGo.NecroBot.Logic.Tasks
             while (pokestopList.Any())
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                
+                //### new realtime snipe
+                await SnipeMSniperTask.CheckMSniperLocation(session, cancellationToken);
+                //###
+
                 //resort
                 pokestopList =
                     pokestopList.OrderBy(

--- a/PoGo.NecroBot.Logic/Tasks/SnipeMSniperTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipeMSniperTask.cs
@@ -1,0 +1,59 @@
+﻿using PoGo.NecroBot.Logic.State;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using PoGo.NecroBot.Logic.Model.Settings;
+using PoGo.NecroBot.Logic.Event;
+using POGOProtos.Enums;
+using Newtonsoft.Json;
+using System.IO;
+
+namespace PoGo.NecroBot.Logic.Tasks
+{
+    public class MSniperInfo
+    {
+        public PokemonId Id { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+    }
+
+    public static class SnipeMSniperTask
+    {
+        public static async Task CheckMSniperLocation(ISession session, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (session.LogicSettings.CatchPokemon)//config is checking
+                {
+                    string pth = Path.Combine(session.LogicSettings.ProfilePath, "SnipeMS.json");
+                    if (!File.Exists(pth))
+                        return;
+                    StreamReader sr = new StreamReader(pth, Encoding.UTF8);
+                    string jsn = sr.ReadToEnd();
+                    sr.Close();
+                    List<MSniperInfo> MSniperLocation = JsonConvert.DeserializeObject<List<MSniperInfo>>(jsn);
+                    File.Delete(pth);
+                    foreach (var location in MSniperLocation)
+                    {
+                        session.EventDispatcher.Send(new SnipeScanEvent
+                        {
+                            Bounds = new Location(location.Latitude, location.Longitude),
+                            PokemonId = location.Id,
+                            Source = "MSniper"
+                        });
+                        await SnipePokemonTask.Snipe(session, session.LogicSettings.PokemonToSnipe.Pokemon, location.Latitude, location.Longitude, cancellationToken);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                session.EventDispatcher.Send(new ErrorEvent { Message = ex.Message });
+            }
+        }
+
+
+    }
+}

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -403,7 +403,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             }
         }
 
-        private static async Task Snipe(ISession session, IEnumerable<PokemonId> pokemonIds, double latitude,
+        public static async Task Snipe(ISession session, IEnumerable<PokemonId> pokemonIds, double latitude,
             double longitude, CancellationToken cancellationToken)
         {
             if (LocsVisited.Contains(new PokemonLocation(latitude, longitude)))


### PR DESCRIPTION
new snipe version 
we don't need close bot for manual snipe
i created snipe program for NecroBot [https://github.com/msx752/MSniper](https://github.com/msx752/MSniper)
-program working same protocol pokesiniper2:// also we can change protocol what we need
-running without username password
-integrated with NecroBot (only communicating on SnipeMS.json)
-program can working multiple necrobot and same pokemon location will send all working bot at the same time
-of course without device information 
-**we dont need SnipeAtPokestops=true**

if any question i answer
**(msniper configured necrobot version 0.9.5 and upper)**