### PR TITLE
Change GPXReader to use ITranslation instead of ISession for GPX initialization

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -128,10 +128,13 @@ namespace PoGo.NecroBot.CLI
                 catch (Exception) { }
             }
 
+            var logicSettings = new LogicSettings(settings);
+            var translation = Translation.Load(logicSettings);
+
             if (settings.GPXConfig.UseGpxPathing)
             {
                 var xmlString = File.ReadAllText(settings.GPXConfig.GpxFile);
-                var readgpx = new GpxReader(xmlString, session);
+                var readgpx = new GpxReader(xmlString, translation);
                 var nearestPt = readgpx.Tracks.SelectMany(
                     (trk, trkindex) =>
                     trk.Segments.SelectMany(
@@ -167,7 +170,7 @@ namespace PoGo.NecroBot.CLI
                 }
             }
 
-            session = new Session(new ClientSettings(settings), new LogicSettings(settings));
+            session = new Session(new ClientSettings(settings), logicSettings, translation);
 
             Teste.Testar(session);
             if (boolNeedsSetup)

--- a/PoGo.NecroBot.Logic/State/Session.cs
+++ b/PoGo.NecroBot.Logic/State/Session.cs
@@ -28,12 +28,16 @@ namespace PoGo.NecroBot.Logic.State
 
     public class Session : ISession
     {
-        public Session(ISettings settings, ILogicSettings logicSettings)
+        public Session(ISettings settings, ILogicSettings logicSettings) : this(settings, logicSettings, Common.Translation.Load(logicSettings))
+        {
+        }
+
+        public Session(ISettings settings, ILogicSettings logicSettings, ITranslation translation)
         {
             Settings = settings;
             LogicSettings = logicSettings;
             EventDispatcher = new EventDispatcher();
-            Translation = Common.Translation.Load(logicSettings);
+            Translation = translation;
             Reset(settings, LogicSettings);
             Stats = new SessionStats();
         }

--- a/PoGo.NecroBot.Logic/Utils/GPXReader.cs
+++ b/PoGo.NecroBot.Logic/Utils/GPXReader.cs
@@ -21,8 +21,6 @@ namespace PoGo.NecroBot.Logic.Utils
     {
         private readonly XmlDocument _gpx = new XmlDocument();
 
-        private ISession _ctx;
-
         public string Author = "";
         public GpsBoundary Bounds = new GpsBoundary();
 
@@ -36,9 +34,12 @@ namespace PoGo.NecroBot.Logic.Utils
         public string UrlName = "";
         public List<Wpt> WayPoints = new List<Wpt>();
 
-        public GpxReader(string xml, ISession session)
+        public GpxReader(string xml, ISession session) : this(xml, session?.Translation)
         {
-            _ctx = session;
+        }
+
+        public GpxReader(string xml, ITranslation translation)
+        {
             if (xml.Equals("")) return;
             _gpx.LoadXml(xml);
             if (_gpx.DocumentElement == null || !_gpx.DocumentElement.Name.Equals("gpx")) return;
@@ -109,8 +110,11 @@ namespace PoGo.NecroBot.Logic.Utils
                     case "topografix:map":
                         break;
                     default:
-                        Logger.Write(session.Translation.GetTranslation(TranslationString.UnhandledGpxData),
-                            LogLevel.Info);
+                        if (translation != null)
+                        {
+                            Logger.Write(translation.GetTranslation(TranslationString.UnhandledGpxData),
+                                LogLevel.Info);
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
Also added a new constructor for Session so we don't have to read the translation twice. Without this fix we get an error if the GPX file has any unhandled elements.