### PR TITLE
By default use only one razzberry per pokemon (fixes #401)

### DIFF
--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -22,7 +22,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public float UseBerriesMinIv = 90;
         public double UseBerriesBelowCatchProbability = 0.20;
         public string UseBerriesOperator = "or";
-        public int MaxBerriesToUsePerPokemon = 3;
+        public int MaxBerriesToUsePerPokemon = 1;
         /*Transfer*/
         public bool TransferWeakPokemon;
         public bool TransferDuplicatePokemon = true;


### PR DESCRIPTION
## Short Description:

This is a quick fix for razzberry spamming, which is not allowed in the real Pokemon Go client.  Set the default to 1 berry to use per pokemon since any setting greater than 1 is dangerous.

## Fixes
#401 
