### PR TITLE
For ban safety, do not rename pokemon by default.

### DIFF
--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -28,8 +28,8 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool TransferDuplicatePokemon = true;
         public bool TransferDuplicatePokemonOnCapture = true;
         /*Rename*/
-        public bool RenamePokemon;
-        public bool RenameOnlyAboveIv = true;
+        public bool RenamePokemon = false;
+        public bool RenameOnlyAboveIv = false;
         public string RenameTemplate = "{1}_{0}";
         /*Favorite*/
         public float FavoriteMinIvPercentage = 95;


### PR DESCRIPTION
## Short Description:
This is also rumored to be an easy way to get flagged - have all your pokemon above a certain IV be renamed.  

The average player does not even know what IV is and would have a hard time easily getting the IV of all their pokemon.  The average player would not rename all pokemon above a certain IV with the format like ```100_Dragonite```.

Users can enable this at their own risk.

