### PR TITLE
Fix error while rebuild Translations folder.

### DIFF
--- a/PoGo.NecroBot.CLI/Config/Translations/translation.th.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.th.json
@@ -654,19 +654,11 @@
     },
     {
       "Key": "firstStartSetupDefaultLatLongPrompt",
-      "Value": "Please enter a Latitude and Longitude (Right click to paste) - Format: Value, Value"
+      "Value": "โปรดป้อน ละติจูดและลองติจูด (คลิกขวาเพื่อวาง) - รูปแบบ: ละติจูด, ลองติจูด"
     },
     {
       "Key": "firstStartSetupDefaultLatLongConfirm",
-      "Value": "Lattitude and Longitude accepted: {0}"
-    },
-    {
-      "Key": "firstStartSetupDefaultLongPrompt",
-      "Value": "โปรดป้อนลองติจูด (คลิกขวาเพื่อวาง)"
-    },
-    {
-      "Key": "firstStartSetupDefaultLongConfirm",
-      "Value": "ลองติจูดคือ : {0}"
+      "Value": "ละติจูด และ ลองติจูด ยอมรับ: {0}"
     },
     {
       "Key": "softBanBypassed",


### PR DESCRIPTION
1. Delete "firstStartSetupDefaultLongPrompt" and "firstStartSetupDefaultLongConfirm" that make an error while rebuild Translations folder.
2. Translate "firstStartSetupDefaultLatLongPrompt" and "firstStartSetupDefaultLatLongConfirm" to Thai language.
