### PR TITLE
Add variance for most numeric settings in config

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -11,6 +11,7 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
 {
     public interface ILogicSettings
     {
+        double GlobalVariancePercentage { get; }
         bool UseWebsocket { get; }
         bool CatchPokemon { get; }
         int CatchPokemonLimit { get; }

--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -27,6 +27,9 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [JsonIgnore]
         public string ProfilePath;
 
+        [DefaultValue(0.05d)]
+        public double GlobalVariancePercentage = 0.05d;
+
         public ConsoleConfig ConsoleConfig = new ConsoleConfig();
         public UpdateConfig UpdateConfig = new UpdateConfig();
         public WebsocketsConfig WebsocketsConfig = new WebsocketsConfig();

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -21,42 +21,59 @@ namespace PoGo.NecroBot.Logic.Model.Settings
             _settings = settings;
         }
 
+        public double GenRandom(double maxValue)
+        {
+            double minValue = maxValue - (maxValue * _settings.GlobalVariancePercentage);
+            return (new Random().NextDouble() * (maxValue - minValue)) + minValue;
+        }
+
+        public int GenRandom(int maxValue)
+        {
+            return (int) Math.Ceiling(GenRandom((double)maxValue));
+        }
+
+        public float GenRandom(float maxValue)
+        {
+            return (float) GenRandom((double)maxValue);
+        }
+
         public string ProfilePath => _settings.ProfilePath;
         public string ProfileConfigPath => _settings.ProfileConfigPath;
         public string GeneralConfigPath => _settings.GeneralConfigPath;
         public bool CheckForUpdates => _settings.UpdateConfig.CheckForUpdates;
         public bool AutoUpdate => _settings.UpdateConfig.AutoUpdate;
         public bool TransferConfigAndAuthOnUpdate => _settings.UpdateConfig.TransferConfigAndAuthOnUpdate;
+        public double GlobalVariancePercentage => _settings.GlobalVariancePercentage;
         public bool UseWebsocket => _settings.WebsocketsConfig.UseWebsocket;
         public bool CatchPokemon => _settings.PokemonConfig.CatchPokemon;
-        public int CatchPokemonLimit => _settings.PokemonConfig.CatchPokemonLimit;
-        public int CatchPokemonLimitMinutes => _settings.PokemonConfig.CatchPokemonLimitMinutes;
-        public int PokeStopLimit => _settings.PokeStopConfig.PokeStopLimit;
-        public int PokeStopLimitMinutes => _settings.PokeStopConfig.PokeStopLimitMinutes;
-        public int SnipeCountLimit => _settings.SnipeConfig.SnipeCountLimit;
-        public int SnipeRestSeconds => _settings.SnipeConfig.SnipeRestSeconds;
+        public int CatchPokemonLimit => GenRandom(_settings.PokemonConfig.CatchPokemonLimit);
+        public int CatchPokemonLimitMinutes => GenRandom(_settings.PokemonConfig.CatchPokemonLimitMinutes);
+        public int PokeStopLimit => GenRandom(_settings.PokeStopConfig.PokeStopLimit);
+        public int PokeStopLimitMinutes => GenRandom(_settings.PokeStopConfig.PokeStopLimitMinutes);
+        public int SnipeCountLimit => GenRandom(_settings.SnipeConfig.SnipeCountLimit);
+        public int SnipeRestSeconds => GenRandom(_settings.SnipeConfig.SnipeRestSeconds);
         public bool TransferWeakPokemon => _settings.PokemonConfig.TransferWeakPokemon;
         public bool DisableHumanWalking => _settings.LocationConfig.DisableHumanWalking;
-        public int MaxBerriesToUsePerPokemon => _settings.PokemonConfig.MaxBerriesToUsePerPokemon;
-        public float KeepMinIvPercentage => _settings.PokemonConfig.KeepMinIvPercentage;
+        public int MaxBerriesToUsePerPokemon => GenRandom(_settings.PokemonConfig.MaxBerriesToUsePerPokemon);
+        public float KeepMinIvPercentage => GenRandom(_settings.PokemonConfig.KeepMinIvPercentage);
         public string KeepMinOperator => _settings.PokemonConfig.KeepMinOperator;
-        public int KeepMinCp => _settings.PokemonConfig.KeepMinCp;
-        public int KeepMinLvl => _settings.PokemonConfig.KeepMinLvl;
+        public int KeepMinCp => GenRandom(_settings.PokemonConfig.KeepMinCp);
+        public int KeepMinLvl => GenRandom(_settings.PokemonConfig.KeepMinLvl);
         public bool UseKeepMinLvl => _settings.PokemonConfig.UseKeepMinLvl;
         public bool AutomaticallyLevelUpPokemon => _settings.PokemonConfig.AutomaticallyLevelUpPokemon;
         public bool OnlyUpgradeFavorites => _settings.PokemonConfig.OnlyUpgradeFavorites;
         public bool UseLevelUpList => _settings.PokemonConfig.UseLevelUpList;
-        public int AmountOfTimesToUpgradeLoop => _settings.PokemonConfig.AmountOfTimesToUpgradeLoop;
+        public int AmountOfTimesToUpgradeLoop => GenRandom(_settings.PokemonConfig.AmountOfTimesToUpgradeLoop);
         public string LevelUpByCPorIv => _settings.PokemonConfig.LevelUpByCPorIv;
-        public int GetMinStarDustForLevelUp => _settings.PokemonConfig.GetMinStarDustForLevelUp;
+        public int GetMinStarDustForLevelUp => GenRandom(_settings.PokemonConfig.GetMinStarDustForLevelUp);
         public bool UseLuckyEggConstantly => _settings.PokemonConfig.UseLuckyEggConstantly;
         public bool UseIncenseConstantly => _settings.PokemonConfig.UseIncenseConstantly;
-        public int UseBerriesMinCp => _settings.PokemonConfig.UseBerriesMinCp;
-        public float UseBerriesMinIv => _settings.PokemonConfig.UseBerriesMinIv;
+        public int UseBerriesMinCp => GenRandom(_settings.PokemonConfig.UseBerriesMinCp);
+        public float UseBerriesMinIv => GenRandom(_settings.PokemonConfig.UseBerriesMinIv);
         public double UseBerriesBelowCatchProbability => _settings.PokemonConfig.UseBerriesBelowCatchProbability;
         public string UseBerriesOperator => _settings.PokemonConfig.UseBerriesOperator;
-        public float UpgradePokemonIvMinimum => _settings.PokemonConfig.UpgradePokemonIvMinimum;
-        public float UpgradePokemonCpMinimum => _settings.PokemonConfig.UpgradePokemonCpMinimum;
+        public float UpgradePokemonIvMinimum => GenRandom(_settings.PokemonConfig.UpgradePokemonIvMinimum);
+        public float UpgradePokemonCpMinimum => GenRandom(_settings.PokemonConfig.UpgradePokemonCpMinimum);
         public string UpgradePokemonMinimumStatsOperator => _settings.PokemonConfig.UpgradePokemonMinimumStatsOperator;
         public double WalkingSpeedInKilometerPerHour => _settings.LocationConfig.WalkingSpeedInKilometerPerHour;
         public bool UseWalkingSpeedVariant => _settings.LocationConfig.UseWalkingSpeedVariant;
@@ -68,10 +85,10 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool TransferDuplicatePokemon => _settings.PokemonConfig.TransferDuplicatePokemon;
         public bool TransferDuplicatePokemonOnCapture => _settings.PokemonConfig.TransferDuplicatePokemonOnCapture;
         public bool UseEggIncubators => _settings.PokemonConfig.UseEggIncubators;
-        public int UseEggIncubatorMinKm => _settings.PokemonConfig.UseEggIncubatorMinKm;
-        public int UseGreatBallAboveCp => _settings.PokemonConfig.UseGreatBallAboveCp;
-        public int UseUltraBallAboveCp => _settings.PokemonConfig.UseUltraBallAboveCp;
-        public int UseMasterBallAboveCp => _settings.PokemonConfig.UseMasterBallAboveCp;
+        public int UseEggIncubatorMinKm => GenRandom(_settings.PokemonConfig.UseEggIncubatorMinKm);
+        public int UseGreatBallAboveCp => GenRandom(_settings.PokemonConfig.UseGreatBallAboveCp);
+        public int UseUltraBallAboveCp => GenRandom(_settings.PokemonConfig.UseUltraBallAboveCp);
+        public int UseMasterBallAboveCp => GenRandom(_settings.PokemonConfig.UseMasterBallAboveCp);
         public double UseGreatBallAboveIv => _settings.PokemonConfig.UseGreatBallAboveIv;
         public double UseUltraBallAboveIv => _settings.PokemonConfig.UseUltraBallAboveIv;
         public double UseMasterBallBelowCatchProbability => _settings.PokemonConfig.UseMasterBallBelowCatchProbability;
@@ -84,26 +101,26 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public int GreatThrowChance => _settings.CustomCatchConfig.GreatThrowChance;
         public int ExcellentThrowChance => _settings.CustomCatchConfig.ExcellentThrowChance;
         public int CurveThrowChance => _settings.CustomCatchConfig.CurveThrowChance;
-        public double ForceGreatThrowOverIv => _settings.CustomCatchConfig.ForceGreatThrowOverIv;
-        public double ForceExcellentThrowOverIv => _settings.CustomCatchConfig.ForceExcellentThrowOverIv;
-        public int ForceGreatThrowOverCp => _settings.CustomCatchConfig.ForceGreatThrowOverCp;
-        public int ForceExcellentThrowOverCp => _settings.CustomCatchConfig.ForceExcellentThrowOverCp;
-        public int DelayBetweenPokemonCatch => _settings.PokemonConfig.DelayBetweenPokemonCatch;
-        public int DelayBetweenPlayerActions => _settings.PlayerConfig.DelayBetweenPlayerActions;
+        public double ForceGreatThrowOverIv => GenRandom(_settings.CustomCatchConfig.ForceGreatThrowOverIv);
+        public double ForceExcellentThrowOverIv => GenRandom(_settings.CustomCatchConfig.ForceExcellentThrowOverIv);
+        public int ForceGreatThrowOverCp => GenRandom(_settings.CustomCatchConfig.ForceGreatThrowOverCp);
+        public int ForceExcellentThrowOverCp => GenRandom(_settings.CustomCatchConfig.ForceExcellentThrowOverCp);
+        public int DelayBetweenPokemonCatch => GenRandom(_settings.PokemonConfig.DelayBetweenPokemonCatch);
+        public int DelayBetweenPlayerActions => GenRandom(_settings.PlayerConfig.DelayBetweenPlayerActions);
         public bool UsePokemonToNotCatchFilter => _settings.PokemonConfig.UsePokemonToNotCatchFilter;
         public bool UsePokemonSniperFilterOnly => _settings.PokemonConfig.UsePokemonSniperFilterOnly;
         public int KeepMinDuplicatePokemon => _settings.PokemonConfig.KeepMinDuplicatePokemon;
         public bool PrioritizeIvOverCp => _settings.PokemonConfig.PrioritizeIvOverCp;
-        public int MaxTravelDistanceInMeters => _settings.LocationConfig.MaxTravelDistanceInMeters;
+        public int MaxTravelDistanceInMeters => GenRandom(_settings.LocationConfig.MaxTravelDistanceInMeters);
         public string GpxFile => _settings.GPXConfig.GpxFile;
         public bool UseGpxPathing => _settings.GPXConfig.UseGpxPathing;
         public bool UseLuckyEggsWhileEvolving => _settings.PokemonConfig.UseLuckyEggsWhileEvolving;
-        public int UseLuckyEggsMinPokemonAmount => _settings.PokemonConfig.UseLuckyEggsMinPokemonAmount;
+        public int UseLuckyEggsMinPokemonAmount => GenRandom(_settings.PokemonConfig.UseLuckyEggsMinPokemonAmount);
         public bool EvolveAllPokemonAboveIv => _settings.PokemonConfig.EvolveAllPokemonAboveIv;
-        public float EvolveAboveIvValue => _settings.PokemonConfig.EvolveAboveIvValue;
+        public float EvolveAboveIvValue => GenRandom(_settings.PokemonConfig.EvolveAboveIvValue);
         public bool RenamePokemon => _settings.PokemonConfig.RenamePokemon;
         public bool RenameOnlyAboveIv => _settings.PokemonConfig.RenameOnlyAboveIv;
-        public float FavoriteMinIvPercentage => _settings.PokemonConfig.FavoriteMinIvPercentage;
+        public float FavoriteMinIvPercentage => GenRandom(_settings.PokemonConfig.FavoriteMinIvPercentage);
         public bool AutoFavoritePokemon => _settings.PokemonConfig.AutoFavoritePokemon;
         public string RenameTemplate => _settings.PokemonConfig.RenameTemplate;
         public int AmountOfPokemonToDisplayOnStart => _settings.ConsoleConfig.AmountOfPokemonToDisplayOnStart;
@@ -112,7 +129,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool DetailedCountsBeforeRecycling => _settings.ConsoleConfig.DetailedCountsBeforeRecycling;
         public bool VerboseRecycling => _settings.RecycleConfig.VerboseRecycling;
         public double RecycleInventoryAtUsagePercentage => _settings.RecycleConfig.RecycleInventoryAtUsagePercentage;
-        public double EvolveKeptPokemonsAtStorageUsagePercentage => _settings.PokemonConfig.EvolveKeptPokemonsAtStorageUsagePercentage;
+        public double EvolveKeptPokemonsAtStorageUsagePercentage => GenRandom(_settings.PokemonConfig.EvolveKeptPokemonsAtStorageUsagePercentage);
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter => _settings.ItemRecycleFilter;
         public ICollection<PokemonId> PokemonsToEvolve => _settings.PokemonsToEvolve;
         public ICollection<PokemonId> PokemonsToLevelUp => _settings.PokemonsToLevelUp;
@@ -123,7 +140,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter => _settings.PokemonsTransferFilter;
         public bool StartupWelcomeDelay => _settings.ConsoleConfig.StartupWelcomeDelay;
         public bool UseGoogleWalk => _settings.GoogleWalkConfig.UseGoogleWalk;
-        public double DefaultStepLength => _settings.GoogleWalkConfig.DefaultStepLength;
+        public double DefaultStepLength => GenRandom(_settings.GoogleWalkConfig.DefaultStepLength);
         public bool UseGoogleWalkCache => _settings.GoogleWalkConfig.Cache;
         public string GoogleApiKey => _settings.GoogleWalkConfig.GoogleAPIKey;
         public string GoogleHeuristic => _settings.GoogleWalkConfig.GoogleHeuristic;
@@ -136,9 +153,9 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseTelegramAPI => _settings.TelegramConfig.UseTelegramAPI;
         public string TelegramAPIKey => _settings.TelegramConfig.TelegramAPIKey;
         public string TelegramPassword => _settings.TelegramConfig.TelegramPassword;
-        public int MinPokeballsToSnipe => _settings.SnipeConfig.MinPokeballsToSnipe;
-        public int MinPokeballsWhileSnipe => _settings.SnipeConfig.MinPokeballsWhileSnipe;
-        public int MaxPokeballsPerPokemon => _settings.PokemonConfig.MaxPokeballsPerPokemon;
+        public int MinPokeballsToSnipe => GenRandom(_settings.SnipeConfig.MinPokeballsToSnipe);
+        public int MinPokeballsWhileSnipe => GenRandom(_settings.SnipeConfig.MinPokeballsWhileSnipe);
+        public int MaxPokeballsPerPokemon => GenRandom(_settings.PokemonConfig.MaxPokeballsPerPokemon);
         public bool RandomlyPauseAtStops => _settings.LocationConfig.RandomlyPauseAtStops;
         public SnipeSettings PokemonToSnipe => _settings.PokemonToSnipe;
         public string SnipeLocationServer => _settings.SnipeConfig.SnipeLocationServer;
@@ -151,16 +168,16 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseSnipeLocationServer => _settings.SnipeConfig.UseSnipeLocationServer;
         public bool UseTransferIvForSnipe => _settings.SnipeConfig.UseTransferIvForSnipe;
         public bool SnipeIgnoreUnknownIv => _settings.SnipeConfig.SnipeIgnoreUnknownIv;
-        public int MinDelayBetweenSnipes => _settings.SnipeConfig.MinDelayBetweenSnipes;
+        public int MinDelayBetweenSnipes => GenRandom(_settings.SnipeConfig.MinDelayBetweenSnipes);
         public double SnipingScanOffset => _settings.SnipeConfig.SnipingScanOffset;
         public bool SnipePokemonNotInPokedex => _settings.SnipeConfig.SnipePokemonNotInPokedex;
         public bool RandomizeRecycle => _settings.RecycleConfig.RandomizeRecycle;
         public int RandomRecycleValue => _settings.RecycleConfig.RandomRecycleValue;
         public bool DelayBetweenRecycleActions => _settings.RecycleConfig.DelayBetweenRecycleActions;
-        public int TotalAmountOfPokeballsToKeep => _settings.RecycleConfig.TotalAmountOfPokeballsToKeep;
-        public int TotalAmountOfPotionsToKeep => _settings.RecycleConfig.TotalAmountOfPotionsToKeep;
-        public int TotalAmountOfRevivesToKeep => _settings.RecycleConfig.TotalAmountOfRevivesToKeep;
-        public int TotalAmountOfBerriesToKeep => _settings.RecycleConfig.TotalAmountOfBerriesToKeep;
+        public int TotalAmountOfPokeballsToKeep => GenRandom(_settings.RecycleConfig.TotalAmountOfPokeballsToKeep);
+        public int TotalAmountOfPotionsToKeep => GenRandom(_settings.RecycleConfig.TotalAmountOfPotionsToKeep);
+        public int TotalAmountOfRevivesToKeep => GenRandom(_settings.RecycleConfig.TotalAmountOfRevivesToKeep);
+        public int TotalAmountOfBerriesToKeep => GenRandom(_settings.RecycleConfig.TotalAmountOfBerriesToKeep);
         public bool UseSnipeLimit => _settings.SnipeConfig.UseSnipeLimit;
         public bool UsePokeStopLimit => _settings.PokeStopConfig.UsePokeStopLimit;
         public bool UseCatchLimit => _settings.PokemonConfig.UseCatchLimit;
@@ -169,19 +186,19 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public int ResumeTrackPt => _settings.LocationConfig.ResumeTrackPt;
 
         public bool HumanWalkingSnipeDisplayList => _settings.HumanWalkSnipeConfig.DisplayPokemonList;
-        public double HumanWalkingSnipeMaxDistance => _settings.HumanWalkSnipeConfig.MaxDistance;
-        public double HumanWalkingSnipeMaxEstimateTime => _settings.HumanWalkSnipeConfig.MaxEstimateTime;
+        public double HumanWalkingSnipeMaxDistance => GenRandom(_settings.HumanWalkSnipeConfig.MaxDistance);
+        public double HumanWalkingSnipeMaxEstimateTime => GenRandom(_settings.HumanWalkSnipeConfig.MaxEstimateTime);
         public bool HumanWalkingSnipeTryCatchEmAll => _settings.HumanWalkSnipeConfig.TryCatchEmAll;
         public bool HumanWalkingSnipeCatchPokemonWhileWalking => _settings.HumanWalkSnipeConfig.CatchPokemonWhileWalking;
         public double HumanWalkingSnipeSnipingScanOffset => _settings.HumanWalkSnipeConfig.SnipingScanOffset;
         public bool HumanWalkingSnipeSpinWhileWalking => _settings.HumanWalkSnipeConfig.SpinWhileWalking;
         public bool HumanWalkingSnipeAlwaysWalkBack => _settings.HumanWalkSnipeConfig.AlwaysWalkback;
-        public int HumanWalkingSnipeCatchEmAllMinBalls => _settings.HumanWalkSnipeConfig.CatchEmAllMinBalls;
+        public int HumanWalkingSnipeCatchEmAllMinBalls => GenRandom(_settings.HumanWalkSnipeConfig.CatchEmAllMinBalls);
         public bool EnableHumanWalkingSnipe => _settings.HumanWalkSnipeConfig.Enable;
 
         public Dictionary<PokemonId, HumanWalkSnipeFilter> HumanWalkSnipeFilters => _settings.HumanWalkSnipeFilters;
 
-        public double HumanWalkingSnipeWalkbackDistanceLimit => _settings.HumanWalkSnipeConfig.WalkbackDistanceLimit;
+        public double HumanWalkingSnipeWalkbackDistanceLimit => GenRandom(_settings.HumanWalkSnipeConfig.WalkbackDistanceLimit);
         public bool HumanWalkingSnipeIncludeDefaultLocation => _settings.HumanWalkSnipeConfig.IncludeDefaultLocation;
     }
 }


### PR DESCRIPTION
## Short Description:

For most numeric settings in config, I've added variance so that you don't always snipe pokemon when you have exactly 20 pokeballs or keep exactly 80 berries in your inventory at most times, etc.

These hard-coded values are slightly varied every time they are read from settings.  The randomness can be configured by global variance percentage:

```
"GlobalVariancePercentage": 0.05
```

This value is used in the calculation of the minimum variance value.

For example if you had ```MinPokeballsToSnipe`` set to 100, then each time the bot checks this value it will be a random value between 95 and 100 (the minimum of 95 is determined by 100 * 0.05 = 95). So sometimes the bot will start sniping when you have 95 balls, or 97 balls, or 98 balls, etc.  just totally randomly.