### PR TITLE
Adjusting handling of player-defined delay when transfering

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -48,6 +48,12 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 family.Candy_++;
 
+                // Padding the TransferEvent with player-choosen delay before instead of after.
+                // This is to remedy too quick transfers, often happening within a second of the
+                // previous action otherwise
+
+                DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
+
                 session.EventDispatcher.Send(new TransferPokemonEvent
                 {
                     Id = duplicatePokemon.PokemonId,
@@ -58,7 +64,6 @@ namespace PoGo.NecroBot.Logic.Tasks
                     FamilyCandies = family.Candy_
                 });
 
-                DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
             }
         }
     }


### PR DESCRIPTION
## Fix for transfer sometimes happening instantly despite player-defined delay
The reason transfers happened instantly after for instance a catch was that the delay was placed after issuing the transfer.

## Solution
Changing so that the delay happens before the first transfer and then first per iteration if there are several transfers piled up.