### PR TITLE
Add setting for using limited incubators or not

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -40,6 +40,7 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         bool TransferDuplicatePokemon { get; }
         bool TransferDuplicatePokemonOnCapture { get; }
         bool UseEggIncubators { get; }
+        bool UseLimitedEggIncubators { get; }
         int UseGreatBallAboveCp { get; }
         int UseUltraBallAboveCp { get; }
         int UseMasterBallAboveCp { get; }

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -68,6 +68,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool TransferDuplicatePokemon => _settings.PokemonConfig.TransferDuplicatePokemon;
         public bool TransferDuplicatePokemonOnCapture => _settings.PokemonConfig.TransferDuplicatePokemonOnCapture;
         public bool UseEggIncubators => _settings.PokemonConfig.UseEggIncubators;
+        public bool UseLimitedEggIncubators => _settings.PokemonConfig.UseLimitedEggIncubators;
         public int UseGreatBallAboveCp => _settings.PokemonConfig.UseGreatBallAboveCp;
         public int UseUltraBallAboveCp => _settings.PokemonConfig.UseUltraBallAboveCp;
         public int UseMasterBallAboveCp => _settings.PokemonConfig.UseMasterBallAboveCp;

--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -13,6 +13,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseIncenseConstantly;
         /*Egg*/
         public bool UseEggIncubators = true;
+        public bool UseLimitedEggIncubators = true;
         public bool UseLuckyEggConstantly;
         public int UseLuckyEggsMinPokemonAmount = 30;
         public bool UseLuckyEggsWhileEvolving;

--- a/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
@@ -81,6 +81,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                     if (egg == null)
                         continue;
 
+                    // Skip (save) limited incubators depending on user choice in config
+                    if (!session.LogicSettings.UseLimitedEggIncubators 
+                        && incubator.ItemId != ItemId.ItemIncubatorBasicUnlimited)
+                        continue;
+
                     var response = await session.Client.Inventory.UseItemEggIncubator(incubator.Id, egg.Id);
                     unusedEggs.Remove(egg);
 


### PR DESCRIPTION
## Add setting for using limited incubators or not

## Explanation
There's still a good reason to save the unlimited incubators.

Without this you cannot save the limited incubators until you reach enough level for them to be useful.. ie above 20ish. The bot will start them all right away and you'll be stuck with only the unlimited one once you start having good use for them.

It's not much use "wasting" limited ones at low levels. You want them to produce high IV mobs once you're at lvl 20. (There's a theory that hatched Pokemons max level is 20 - no use saving anything after that level thus).

