### PR TITLE
Add auto-complete tutorial option

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -135,6 +135,8 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         bool UsePokeStopLimit { get; }
         bool UseCatchLimit { get; }
         bool UseNearActionRandom { get; }
+        bool AutoCompleteTutorial { get; }
+        string DesiredNickname { get; }
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 
         ICollection<PokemonId> PokemonsToEvolve { get; }

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -91,6 +91,8 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public int DelayBetweenPokemonCatch => _settings.PokemonConfig.DelayBetweenPokemonCatch;
         public int DelayBetweenPlayerActions => _settings.PlayerConfig.DelayBetweenPlayerActions;
         public bool UseNearActionRandom => _settings.PlayerConfig.UseNearActionRandom;
+        public bool AutoCompleteTutorial => _settings.PlayerConfig.AutoCompleteTutorial;
+        public string DesiredNickname => _settings.PlayerConfig.DesiredNickname;
         public bool UsePokemonToNotCatchFilter => _settings.PokemonConfig.UsePokemonToNotCatchFilter;
         public bool UsePokemonSniperFilterOnly => _settings.PokemonConfig.UsePokemonSniperFilterOnly;
         public int KeepMinDuplicatePokemon => _settings.PokemonConfig.KeepMinDuplicatePokemon;

--- a/PoGo.NecroBot.Logic/Model/Settings/PlayerConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PlayerConfig.cs
@@ -4,5 +4,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
     {
         public int DelayBetweenPlayerActions = 5000;
         public bool UseNearActionRandom = true;
+        public bool AutoCompleteTutorial = false;
+        public string DesiredNickname;
     }
 }

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Service\TelegramService.cs" />
     <Compile Include="Model\Settings\LogicSettings.cs" />
     <Compile Include="Service\YoursDirectionsService.cs" />
+    <Compile Include="State\CheckTosState.cs" />
     <Compile Include="State\SessionStats.cs" />
     <Compile Include="Strategies\Walk\BaseWalkStrategy.cs" />
     <Compile Include="Strategies\Walk\FlyStrategy.cs" />

--- a/PoGo.NecroBot.Logic/State/CheckTosState.cs
+++ b/PoGo.NecroBot.Logic/State/CheckTosState.cs
@@ -1,0 +1,191 @@
+﻿#region using directives
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Protobuf.Collections;
+using POGOProtos.Data.Player;
+using POGOProtos.Enums;
+using POGOProtos.Networking.Responses;
+using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Utils;
+
+#endregion
+
+namespace PoGo.NecroBot.Logic.State
+{
+    public class CheckTosState : IState
+    {
+        public async Task<IState> Execute(ISession session, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (session.LogicSettings.AutoCompleteTutorial)
+            {
+                var tutState = session.Profile.PlayerData.TutorialState;
+                if (!tutState.Contains(TutorialState.LegalScreen))
+                {
+                    await
+                        session.Client.Misc.MarkTutorialComplete(new RepeatedField<TutorialState>()
+                        {
+                            TutorialState.LegalScreen
+                        });
+                    session.EventDispatcher.Send(new NoticeEvent()
+                    {
+                        Message = "Just read the Niantic ToS, looks legit, accepting!"
+                    });
+                    await DelayingUtils.DelayAsync(9000, 2000);
+                }
+                if (!tutState.Contains(TutorialState.AvatarSelection))
+                {
+                    var gen = new Random().Next(2) == 1 ? Gender.Male : Gender.Female;
+                    var avatarRes = await session.Client.Player.SetAvatar(new PlayerAvatar()
+                    {
+                        Backpack = 0,
+                        Eyes = 0,
+                        Gender = gen,
+                        Hair = 0,
+                        Hat = 0,
+                        Pants = 0,
+                        Shirt = 0,
+                        Shoes = 0,
+                        Skin = 0
+                    });
+                    if (avatarRes.Status == SetAvatarResponse.Types.Status.AvatarAlreadySet ||
+                        avatarRes.Status == SetAvatarResponse.Types.Status.Success)
+                    {
+                        await session.Client.Misc.MarkTutorialComplete(new RepeatedField<TutorialState>()
+                        {
+                            TutorialState.AvatarSelection
+                        });
+                        session.EventDispatcher.Send(new NoticeEvent()
+                        {
+                            Message = $"Selected your avatar, now you are {gen}!"
+                        });
+                    }
+                }
+                if (!tutState.Contains(TutorialState.PokemonCapture))
+                {
+                    await CatchFirstPokemon(session);
+                }
+                if (!tutState.Contains(TutorialState.NameSelection))
+                {
+                    await SelectNicnname(session);
+                }
+                if (!tutState.Contains(TutorialState.FirstTimeExperienceComplete))
+                {
+                    await
+                        session.Client.Misc.MarkTutorialComplete(new RepeatedField<TutorialState>()
+                        {
+                            TutorialState.FirstTimeExperienceComplete
+                        });
+                    session.EventDispatcher.Send(new NoticeEvent()
+                    {
+                        Message = "First time experience complete, looks like i just spinned an virtual pokestop :P"
+                    });
+                    await DelayingUtils.DelayAsync(3000, 2000);
+                }
+            }
+            return new FarmState();
+        }
+
+        public async Task<bool> CatchFirstPokemon(ISession session)
+        {
+            var firstPokeList = new List<PokemonId>
+            {
+                PokemonId.Bulbasaur,
+                PokemonId.Charmander,
+                PokemonId.Squirtle
+            };
+
+            var firstpokeRnd = new Random().Next(0, 2);
+            var firstPoke = firstPokeList[firstpokeRnd];
+
+            var res = await session.Client.Encounter.EncounterTutorialComplete(firstPoke);
+            await DelayingUtils.DelayAsync(7000, 2000);
+            if (res.Result != EncounterTutorialCompleteResponse.Types.Result.Success) return false;
+            session.EventDispatcher.Send(new NoticeEvent()
+            {
+                Message = $"Caught Tutorial pokemon! it's {firstPoke}!"
+            });
+            return true;
+        }
+
+        public async Task<bool> SelectNicnname(ISession session)
+        {
+            if (string.IsNullOrEmpty(session.LogicSettings.DesiredNickname))
+            {
+                session.EventDispatcher.Send(new NoticeEvent()
+                {
+                    Message = "You didn't pick the desired nickname!"
+                });
+                return false;
+            }
+
+            if (session.LogicSettings.DesiredNickname.Length > 15)
+            {
+                session.EventDispatcher.Send(new NoticeEvent()
+                {
+                    Message = "You selected too long Desired name, max length: 15!"
+                });
+                return false;
+            }
+			
+            var res = await session.Client.Misc.ClaimCodename(session.LogicSettings.DesiredNickname);
+            if (res.Status == ClaimCodenameResponse.Types.Status.Success)
+            {
+                session.EventDispatcher.Send(new NoticeEvent()
+                {
+                    Message = $"Your name is now: {res.Codename}"
+                });
+                await session.Client.Misc.MarkTutorialComplete(new RepeatedField<TutorialState>()
+                        {
+                            TutorialState.NameSelection
+                        });
+            }
+            else if (res.Status == ClaimCodenameResponse.Types.Status.CodenameChangeNotAllowed || res.Status == ClaimCodenameResponse.Types.Status.CurrentOwner)
+            {
+                await session.Client.Misc.MarkTutorialComplete(new RepeatedField<TutorialState>()
+                        {
+                            TutorialState.NameSelection
+                        });
+            }
+            else
+            {
+                var errorText = "Niantic error";
+                switch (res.Status)
+                {
+                    case ClaimCodenameResponse.Types.Status.Unset:
+                        errorText = "Unset, somehow";
+                        break;
+                    case ClaimCodenameResponse.Types.Status.Success:
+                        errorText = "No errors, nickname changed";
+                        break;
+                    case ClaimCodenameResponse.Types.Status.CodenameNotAvailable:
+                        errorText = "That nickname isn't available, pick another one and restart the bot!";
+                        break;
+                    case ClaimCodenameResponse.Types.Status.CodenameNotValid:
+                        errorText = "That nickname isn't valid, pick another one!";
+                        break;
+                    case ClaimCodenameResponse.Types.Status.CurrentOwner:
+                        errorText = "You already own that nickname!";
+                        break;
+                    case ClaimCodenameResponse.Types.Status.CodenameChangeNotAllowed:
+                        errorText = "You can't change your nickname anymore!";
+                        break;
+                }
+
+                session.EventDispatcher.Send(new NoticeEvent()
+                {
+                    Message = $"Name selection failed! Error: {errorText}"
+                });
+
+                // Pause here so the user can restart the bot.
+                Console.ReadKey();
+            }
+            await DelayingUtils.DelayAsync(3000, 2000);
+            return res.Status == ClaimCodenameResponse.Types.Status.Success;
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/State/InfoState.cs
+++ b/PoGo.NecroBot.Logic/State/InfoState.cs
@@ -14,7 +14,8 @@ namespace PoGo.NecroBot.Logic.State
         {
             cancellationToken.ThrowIfCancellationRequested();
             await DisplayPokemonStatsTask.Execute(session);
-            return new FarmState();
+
+            return new CheckTosState();
         }
     }
 }


### PR DESCRIPTION
## Short Description:
Added option for the bot to auto-complete the tutorial.  

For new PokemonGo accounts this will:

1. Randomly select your gender.
2. Select the default set of clothing.
3. Set the nickname for your avatar (configured in ```config.json```)
4. Catch the first pokemon
5. Spin the first pokestop.

This is disabled by default.  To enable this feature:

Set:
```
"AutoCompleteTutorial": true,
"DesiredNickname": "MyNickname"
```

For ban safety this is very important since you usually complete the tutorial either on your real device or on an emulator like Nox before swapping to the bot, which seems very suspicious.

## Dependencies:
Before this can be merged, https://github.com/NoxxDev/NecroBot-Rocket-API/pull/8 must be merged.

## Credits:
Credit goes to Lunat1q who implemented this in his fork of PokeMobBot.