### PR TITLE
Implemented Settings for Min and Max Evolve Delay

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -186,5 +186,7 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         double HumanWalkingSnipeMaxSpeedUpSpeed { get; }
         int HumanWalkingSnipeDelayTimeAtDestination { get; }
         bool HumanWalkingSnipeAllowSpeedUp { get; }
+        int MinEvolveActionDelay { get; }
+        int MaxEvolveActionDelay { get; }
     }
 }

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -90,6 +90,8 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public int ForceExcellentThrowOverCp => _settings.CustomCatchConfig.ForceExcellentThrowOverCp;
         public int DelayBetweenPokemonCatch => _settings.PokemonConfig.DelayBetweenPokemonCatch;
         public int DelayBetweenPlayerActions => _settings.PlayerConfig.DelayBetweenPlayerActions;
+        public int MinEvolveActionDelay => _settings.PlayerConfig.MinEvolveActionDelay;
+        public int MaxEvolveActionDelay => _settings.PlayerConfig.MaxEvolveActionDelay;
         public bool UseNearActionRandom => _settings.PlayerConfig.UseNearActionRandom;
         public bool AutoCompleteTutorial => _settings.PlayerConfig.AutoCompleteTutorial;
         public string DesiredNickname => _settings.PlayerConfig.DesiredNickname;

--- a/PoGo.NecroBot.Logic/Model/Settings/PlayerConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PlayerConfig.cs
@@ -3,6 +3,8 @@ namespace PoGo.NecroBot.Logic.Model.Settings
     public class PlayerConfig
     {
         public int DelayBetweenPlayerActions = 5000;
+        public int MinEvolveActionDelay = 22500;
+        public int MaxEvolveActionDelay = 25500;
         public bool UseNearActionRandom = true;
         public bool AutoCompleteTutorial = false;
         public string DesiredNickname;

--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -111,6 +111,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
         private static async Task evolve(ISession session, List<PokemonData> pokemonToEvolve)
         {
+            Random rnd = new Random();
             foreach (var pokemon in pokemonToEvolve)
             {
                 // no cancellationToken.ThrowIfCancellationRequested here, otherwise the lucky egg would be wasted.
@@ -125,7 +126,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 });
                 if (!pokemonToEvolve.Last().Equals(pokemon))
                 {
-                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
+                    DelayingUtils.Delay(rnd.Next(session.LogicSettings.MinEvolveActionDelay, session.LogicSettings.MaxEvolveActionDelay), 0);
                 }
             }
         }


### PR DESCRIPTION
## Short Description:
Implemented Settings for Min and Max Evolve Delay, which is now randomized and independant from regular player actions

MinEvolveActionDelay = Minimum time in milliseconds the bot will wait between evolutions
MaxEvolveActionDelay = Maximum time in milliseconds the bot will wait between evolutions

## Fixes (provide links to github issues if you can):
#673 
